### PR TITLE
write prometheus plugin

### DIFF
--- a/contrib/redhat/collectd.spec
+++ b/contrib/redhat/collectd.spec
@@ -281,7 +281,7 @@
 
 Summary:	Statistics collection and monitoring daemon
 Name:		collectd
-Version:	5.7.5.ddn
+Version:	5.7.6.ddn
 Release:	1.g%{?rev}%{?dist}
 URL:		https://collectd.org
 Source0:	%{_sourcedir}/%{name}-%{version}.tar.bz2

--- a/src/daemon/common.c
+++ b/src/daemon/common.c
@@ -329,6 +329,25 @@ int strsplit(char *string, char **fields, size_t size) {
   return (int)i;
 }
 
+int strsplit_delimiter(char *string, char **fields, size_t size, char *delimiter) {
+  size_t i;
+  char *ptr;
+  char *saveptr;
+
+  i = 0;
+  ptr = string;
+  saveptr = NULL;
+  while ((fields[i] = strtok_r(ptr, delimiter, &saveptr)) != NULL) {
+    ptr = NULL;
+    i++;
+
+    if (i >= size)
+      break;
+  }
+
+  return (int)i;
+}
+
 int strjoin(char *buffer, size_t buffer_size, char **fields, size_t fields_num,
             const char *sep) {
   size_t avail = 0;

--- a/src/daemon/common.h
+++ b/src/daemon/common.h
@@ -138,6 +138,27 @@ int strsplit(char *string, char **fields, size_t size);
 
 /*
  * NAME
+ *   strsplit
+ *
+ * DESCRIPTION
+ *   Splits a string into parts and stores pointers to the parts in `fields'.
+ *
+ * PARAMETERS
+ *   `string'      String to split. This string will be modified. `fields' will
+ *                 contain pointers to parts of this string, so free'ing it
+ *                 will destroy `fields' as well.
+ *   `fields'      Array of strings where pointers to the parts will be stored.
+ *   `size'        Number of elements in the array. No more than `size'
+ *                 pointers will be stored in `fields'.
+ *   `delimiter'   Character at which the string is split.
+ *
+ * RETURN VALUE
+ *    Returns the number of parts stored in `fields'.
+ */
+int strsplit_delimiter(char *string, char **fields, size_t size, char *delimiter);
+
+/*
+ * NAME
  *   strjoin
  *
  * DESCRIPTION

--- a/src/df.c
+++ b/src/df.c
@@ -275,7 +275,7 @@ static int df_read(void) {
                     (gauge_t)(blk_free * blocksize));
       df_submit_one(disk_name, "df_complex", "avail",
                     (gauge_t)(blk_avail * blocksize));
-      df_submit_one(disk_name, "df_complex", "total",
+      df_submit_one(disk_name, "df_complex", "size",
                     (gauge_t)(blk_total * blocksize));
       df_submit_one(disk_name, "df_complex", "reserved",
                     (gauge_t)(blk_reserved * blocksize));
@@ -289,7 +289,7 @@ static int df_read(void) {
                       (gauge_t)((float_t)(blk_free) / statbuf.f_blocks * 100));
         df_submit_one(disk_name, "percent_bytes", "avail",
                       (gauge_t)((float_t)(blk_avail) / statbuf.f_blocks * 100));
-        df_submit_one(disk_name, "percent_bytes", "total",
+        df_submit_one(disk_name, "percent_bytes", "size",
                       (gauge_t)((float_t)(blk_total) / statbuf.f_blocks * 100));
         df_submit_one(
             disk_name, "percent_bytes", "reserved",

--- a/src/df.c
+++ b/src/df.c
@@ -167,6 +167,8 @@ static int df_read(void) {
     char disk_name[256];
     cu_mount_t *dup_ptr;
     uint64_t blk_free;
+    uint64_t blk_avail;
+    uint64_t blk_total;
     uint64_t blk_reserved;
     uint64_t blk_used;
 
@@ -262,13 +264,19 @@ static int df_read(void) {
     if (statbuf.f_blocks < statbuf.f_bfree)
       statbuf.f_blocks = statbuf.f_bfree;
 
-    blk_free = (uint64_t)statbuf.f_bavail;
+    blk_free = (uint64_t)statbuf.f_bfree;
+    blk_avail = (uint64_t)statbuf.f_bavail;
+    blk_total = (uint64_t)statbuf.f_blocks;
     blk_reserved = (uint64_t)(statbuf.f_bfree - statbuf.f_bavail);
     blk_used = (uint64_t)(statbuf.f_blocks - statbuf.f_bfree);
 
     if (values_absolute) {
       df_submit_one(disk_name, "df_complex", "free",
                     (gauge_t)(blk_free * blocksize));
+      df_submit_one(disk_name, "df_complex", "avail",
+                    (gauge_t)(blk_avail * blocksize));
+      df_submit_one(disk_name, "df_complex", "total",
+                    (gauge_t)(blk_total * blocksize));
       df_submit_one(disk_name, "df_complex", "reserved",
                     (gauge_t)(blk_reserved * blocksize));
       df_submit_one(disk_name, "df_complex", "used",
@@ -279,6 +287,10 @@ static int df_read(void) {
       if (statbuf.f_blocks > 0) {
         df_submit_one(disk_name, "percent_bytes", "free",
                       (gauge_t)((float_t)(blk_free) / statbuf.f_blocks * 100));
+        df_submit_one(disk_name, "percent_bytes", "avail",
+                      (gauge_t)((float_t)(blk_avail) / statbuf.f_blocks * 100));
+        df_submit_one(disk_name, "percent_bytes", "total",
+                      (gauge_t)((float_t)(blk_total) / statbuf.f_blocks * 100));
         df_submit_one(
             disk_name, "percent_bytes", "reserved",
             (gauge_t)((float_t)(blk_reserved) / statbuf.f_blocks * 100));
@@ -291,6 +303,8 @@ static int df_read(void) {
     /* inode handling */
     if (report_inodes && statbuf.f_files != 0 && statbuf.f_ffree != 0) {
       uint64_t inode_free;
+      uint64_t inode_avail;
+      uint64_t inode_total;
       uint64_t inode_reserved;
       uint64_t inode_used;
 
@@ -300,7 +314,9 @@ static int df_read(void) {
       if (statbuf.f_files < statbuf.f_ffree)
         statbuf.f_files = statbuf.f_ffree;
 
-      inode_free = (uint64_t)statbuf.f_favail;
+      inode_free = (uint64_t)statbuf.f_ffree;
+      inode_avail = (uint64_t)statbuf.f_favail;
+      inode_total = (uint64_t)statbuf.f_files;
       inode_reserved = (uint64_t)(statbuf.f_ffree - statbuf.f_favail);
       inode_used = (uint64_t)(statbuf.f_files - statbuf.f_ffree);
 
@@ -309,6 +325,12 @@ static int df_read(void) {
           df_submit_one(
               disk_name, "percent_inodes", "free",
               (gauge_t)((float_t)(inode_free) / statbuf.f_files * 100));
+          df_submit_one(
+              disk_name, "percent_inodes", "avail",
+              (gauge_t)((float_t)(inode_avail) / statbuf.f_files * 100));
+          df_submit_one(
+              disk_name, "percent_inodes", "total",
+              (gauge_t)((float_t)(inode_total) / statbuf.f_files * 100));
           df_submit_one(
               disk_name, "percent_inodes", "reserved",
               (gauge_t)((float_t)(inode_reserved) / statbuf.f_files * 100));
@@ -320,6 +342,8 @@ static int df_read(void) {
       }
       if (values_absolute) {
         df_submit_one(disk_name, "df_inodes", "free", (gauge_t)inode_free);
+        df_submit_one(disk_name, "df_inodes", "avail", (gauge_t)inode_avail);
+        df_submit_one(disk_name, "df_inodes", "total", (gauge_t)inode_total);
         df_submit_one(disk_name, "df_inodes", "reserved",
                       (gauge_t)inode_reserved);
         df_submit_one(disk_name, "df_inodes", "used", (gauge_t)inode_used);

--- a/src/filedata_config.c
+++ b/src/filedata_config.c
@@ -392,6 +392,8 @@ void filedata_math_entry_free(struct filedata_math_entry *fme)
 	free(fme->fme_operation);
 	free(fme->fme_right_operand);
 	free(fme->fme_tsdb_name);
+	free(fme->fme_plugin);
+	free(fme->fme_plugin_instance);
 	free(fme->fme_type);
 	free(fme->fme_type_instance);
 	free(fme);

--- a/src/filedata_config.h
+++ b/src/filedata_config.h
@@ -317,7 +317,8 @@ struct filedata_math_entry {
 	char		*fme_left_operand;
 	char		*fme_right_operand;
 	char		*fme_operation;
-
+	char		*fme_plugin;
+	char		*fme_plugin_instance;
 	char		*fme_tsdb_name;	/* submit instance */
 	char		*fme_type;
 	char		*fme_type_instance;

--- a/src/filedata_read.c
+++ b/src/filedata_read.c
@@ -1538,8 +1538,10 @@ filedata_submit_math_instance(struct filedata_entry *entry)
 							fme->fme_operation,
 							fhme_found->fhme_value);
 				filedata_instance_submit(fhme->fhme_host,
-						fhme->fhme_plugin,
-						fhme->fhme_plugin_instance,
+						fme->fme_plugin ?
+						fme->fme_plugin : fhme->fhme_plugin,
+						fme->fme_plugin_instance ?
+						fme->fme_plugin_instance : fhme->fhme_plugin_instance,
 						fme->fme_type ?
 						fme->fme_type : fhme->fhme_type,
 						fme->fme_type_instance ?

--- a/src/filedata_xml.c
+++ b/src/filedata_xml.c
@@ -144,6 +144,8 @@ filedata_entry_free(struct filedata_entry *entry)
 #define FILEDATA_XML_ME_OPERATION	"operation"
 #define FILEDATA_XML_ME_RIGHT_OPERAND	"right_operand"
 #define FILEDATA_XML_ME_TSDB_NAME	"tsdb_name"
+#define FILEDATA_XML_ME_PLUGIN		"plugin"
+#define FILEDATA_XML_ME_PLUGIN_INSTANCE	"plugin_instance"
 #define FILEDATA_XML_ME_TYPE		"type"
 #define FILEDATA_XML_ME_TYPE_INSTANCE	"type_instance"
 #define FILEDATA_XML_SUBPATH		"subpath"
@@ -1083,6 +1085,14 @@ filedata_xml_math_entry_parse(struct filedata_definition *definition,
 			   FILEDATA_XML_ME_TSDB_NAME) == 0) {
 			status = filedata_xml_get_str(tmp,
 					&fme->fme_tsdb_name);
+		} else if (strcmp((char *)tmp->name,
+			   FILEDATA_XML_ME_PLUGIN) == 0) {
+			status = filedata_xml_get_str(tmp,
+					&fme->fme_plugin);
+		} else if (strcmp((char *)tmp->name,
+			   FILEDATA_XML_ME_PLUGIN_INSTANCE) == 0) {
+			status = filedata_xml_get_str(tmp,
+					&fme->fme_plugin_instance);
 		} else if (strcmp((char *)tmp->name,
 			   FILEDATA_XML_ME_TYPE) == 0) {
 			status = filedata_xml_get_str(tmp,

--- a/src/memory.c
+++ b/src/memory.c
@@ -271,6 +271,7 @@ static int memory_read_internal(value_list_t *vl) {
   _Bool detailed_slab_info = 0;
 
   gauge_t mem_total = 0;
+  gauge_t mem_avail = 0;
   gauge_t mem_used = 0;
   gauge_t mem_buffered = 0;
   gauge_t mem_cached = 0;
@@ -292,6 +293,8 @@ static int memory_read_internal(value_list_t *vl) {
       val = &mem_total;
     else if (strncasecmp(buffer, "MemFree:", 8) == 0)
       val = &mem_free;
+    else if (strncasecmp(buffer, "MemAvailable:", 13) == 0)
+      val = &mem_avail;
     else if (strncasecmp(buffer, "Buffers:", 8) == 0)
       val = &mem_buffered;
     else if (strncasecmp(buffer, "Cached:", 7) == 0)
@@ -330,12 +333,14 @@ static int memory_read_internal(value_list_t *vl) {
    * kernels. So SReclaimable/SUnreclaim are submitted if available, and Slab
    * if not. */
   if (detailed_slab_info)
-    MEMORY_SUBMIT("MemUsed", mem_used, "Buffers", mem_buffered, "Cached",
-                  mem_cached, "MemFree", mem_free, "SUnreclaim",
-                  mem_slab_unreclaimable, "SReclaimable", mem_slab_reclaimable);
+    MEMORY_SUBMIT("MemTotal", mem_total, "MemAvailable", mem_avail, "MemUsed",
+                  mem_used, "Buffers", mem_buffered, "Cached", mem_cached,
+                  "MemFree", mem_free, "SUnreclaim", mem_slab_unreclaimable,
+                  "SReclaimable", mem_slab_reclaimable);
   else
-    MEMORY_SUBMIT("MemUsed", mem_used, "Buffers", mem_buffered, "Cached",
-                  mem_cached, "MemFree", mem_free, "Slab", mem_slab_total);
+    MEMORY_SUBMIT("MemTotal", mem_total, "MemAvailable", mem_avail, "MemUsed",
+                  mem_used, "Buffers", mem_buffered, "Cached", mem_cached,
+                  "MemFree", mem_free, "Slab", mem_slab_total);
 /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT

--- a/src/memory.c
+++ b/src/memory.c
@@ -330,12 +330,12 @@ static int memory_read_internal(value_list_t *vl) {
    * kernels. So SReclaimable/SUnreclaim are submitted if available, and Slab
    * if not. */
   if (detailed_slab_info)
-    MEMORY_SUBMIT("used", mem_used, "buffered", mem_buffered, "cached",
-                  mem_cached, "free", mem_free, "slab_unrecl",
-                  mem_slab_unreclaimable, "slab_recl", mem_slab_reclaimable);
+    MEMORY_SUBMIT("MemUsed", mem_used, "Buffers", mem_buffered, "Cached",
+                  mem_cached, "MemFree", mem_free, "SUnreclaim",
+                  mem_slab_unreclaimable, "SReclaimable", mem_slab_reclaimable);
   else
-    MEMORY_SUBMIT("used", mem_used, "buffered", mem_buffered, "cached",
-                  mem_cached, "free", mem_free, "slab", mem_slab_total);
+    MEMORY_SUBMIT("MemUsed", mem_used, "Buffers", mem_buffered, "Cached",
+                  mem_cached, "MemFree", mem_free, "Slab", mem_slab_total);
 /* #endif KERNEL_LINUX */
 
 #elif HAVE_LIBKSTAT

--- a/src/write_prometheus.c
+++ b/src/write_prometheus.c
@@ -438,6 +438,13 @@ static int metric_cmp(void const *a, void const *b) {
       }                                                                            \
     }                                                                              \
                                                                                    \
+    if (strlen((vl)->type) != 0) {                                                 \
+      if (strcmp((vl)->type, "derive") != 0 && strcmp((vl)->type, "gauge") != 0) { \
+        (m)->label[(m)->n_label]->name = "kind";                                   \
+        (m)->label[(m)->n_label]->value = (char *)(vl)->type;                      \
+        (m)->n_label++;                                                            \
+      }                                                                            \
+    }                                                                              \
     if (strlen((vl)->type_instance) != 0 && add_type) {                            \
       (m)->label[(m)->n_label]->name = "type";                                     \
       (m)->label[(m)->n_label]->value = (char *)(vl)->type_instance;               \

--- a/version-gen.sh
+++ b/version-gen.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DEFAULT_VERSION="5.7.5.git"
+DEFAULT_VERSION="5.7.6.git"
 
 if [ -d .git ]; then
 	VERSION="`git describe --dirty=+ --abbrev=7 2> /dev/null | grep collectd | sed -e 's/^collectd-//' -e 's/-/./g'`"


### PR DESCRIPTION
- Modifications in memory, df, and filedata plugins to enable extra metrics available in lustre_exporter.
- Modified write_prometheus plugin to make the generation of metrics labels more in line with luster_exporter.
- Modifications in write_prometheus  to expose multiple fields(tags) fetched from filedata plugin rather than the three default fields.